### PR TITLE
Sprint-15 CHE-2263 Unassigned peripherals not updated in Peripheral Manager App

### DIFF
--- a/program1.txt
+++ b/program1.txt
@@ -1,4 +1,6 @@
+Non-Conflicting line1
 Line 1 of code
 Line x of code
 
 Sample code to be cherrypicked
+Conflicting line1


### PR DESCRIPTION
Linked Issue
CHE-2263 - Unassigned peripheral scanned after adding a new peripheral with invalid mac ID but same type

Description
When multiple peripherals are unassigned during offline condition, the peripherals are usually not removed from the peripheral app after the app comes online.
Cause- Updates to the db happen faster than it could be processed.
Fix- Added a buffered flow to observe the db hence eliminating loss of db updates